### PR TITLE
Deprecate StandardKeyEnumeration

### DIFF
--- a/StandardsRegExt-v1.1.xsd
+++ b/StandardsRegExt-v1.1.xsd
@@ -333,32 +333,6 @@
       </xs:complexContent>
    </xs:complexType>
 
-   <xs:complexType name="StandardKeyEnumeration">
-      <xs:annotation>
-         <xs:documentation>
-            A registered set of related keys.  Each key can be
-            uniquely identified by combining the IVOA identifier of
-            this resource with the key name separated by the URI
-            fragment delimiter, #, as in: ivoa-identifier#key-name
-         </xs:documentation>
-      </xs:annotation>
-      <xs:complexContent>
-         <xs:extension base="vr:Resource">
-            <xs:sequence>
-               <xs:element name="key" type="vstd:StandardKey"
-                           maxOccurs="unbounded" minOccurs="1">
-                 <xs:annotation>
-                    <xs:documentation>
-                      the name and definition of a key--a named concept,
-                      feature, or property.
-                    </xs:documentation>
-                 </xs:annotation>
-               </xs:element>
-            </xs:sequence>
-         </xs:extension>
-      </xs:complexContent>
-   </xs:complexType>
-
    <xs:complexType name="StandardKey">
       <xs:annotation>
          <xs:documentation>

--- a/StandardsRegExt.tex
+++ b/StandardsRegExt.tex
@@ -400,10 +400,10 @@ are specifically for independently documented standards:
        types.  When such names are being defined as part of an IVOA
        standard, it is recommended that the \xmlel{vstd:Standard} or
        \xmlel{vstd:ServiceStandard} record corresponding to the
-       IVOA standard document be used to define the names.  The
+       IVOA standard document be used to define the names.  The deprecated
        \xmlel{vstd:StandardKeyEnumeration} was originally envisioned to
        as a container for names.  With the adoption of Vocabularies in
-       the VO 2 \citep{2021ivoa.spec.0525D}, this type has probably
+       the VO 2 \citep{2021ivoa.spec.0525D}, this type has 
        become obsolete.
 \end{admonition}
 
@@ -1081,69 +1081,6 @@ defined by the standard.
 
 
 
-\subsubsection{StandardKeyEnumeration}
-
-The \xmlel{vstd:StandardKeyEnumeration} resource type is available
-for collecting definitions of related, standard keys.  Each key defined
-within this resource can then be referred to by a unique IVOA
-Identifier URI (see Sect.~\ref{sect:keys}).  To support
-this, the \xmlel{vstd:StandardKeyEnumeration} resource simply
-adds the \xmlel{key} element to the standard core
-metadata.
-
-% GENERATED: !schemadoc StandardsRegExt-v1.1.xsd StandardKeyEnumeration
-\begin{generated}
-\begingroup
-        \renewcommand*\descriptionlabel[1]{%
-        \hbox to 5.5em{\emph{#1}\hfil}}\vspace{2ex}\noindent\textbf{\xmlel{vstd:StandardKeyEnumeration} Type Schema Documentation}
-
-\noindent{\small
-            A registered set of related keys.  Each key can be
-            uniquely identified by combining the IVOA identifier of
-            this resource with the key name separated by the URI
-            fragment delimiter, \#, as in: ivoa-identifier\#key-name
-         \par}
-
-\vspace{1ex}\noindent\textbf{\xmlel{vstd:StandardKeyEnumeration} Type Schema Definition}
-
-\begin{lstlisting}[language=XML,basicstyle=\footnotesize]
-<xs:complexType name="StandardKeyEnumeration" >
-  <xs:complexContent >
-    <xs:extension base="vr:Resource" >
-      <xs:sequence >
-        <xs:element name="key" type="vstd:StandardKey"
-                  maxOccurs="unbounded"
-                  minOccurs="1" />
-      </xs:sequence>
-    </xs:extension>
-  </xs:complexContent>
-</xs:complexType>
-\end{lstlisting}
-
-\vspace{0.5ex}\noindent\textbf{\xmlel{vstd:StandardKeyEnumeration} Extension Metadata Elements}
-
-\begingroup\small\begin{bigdescription}\item[Element \xmlel{key}]
-\begin{description}
-\item[Type] composite: \xmlel{vstd:StandardKey}
-\item[Meaning]
-                      the name and definition of a key--a named concept,
-                      feature, or property.
-
-\item[Occurrence] required; multiple occurrences allowed.
-
-\end{description}
-
-
-\end{bigdescription}\endgroup
-
-\endgroup
-\end{generated}
-
-% /GENERATED
-
-The contents of the \xmlel{key} element is described in
-the next section.
-
 
 
 \subsection{Defining Keys: StandardKey and StandardKeyURI}
@@ -1321,6 +1258,7 @@ as distributed by the Registry of Registries.
 \subsection{Changes since Rec-1.0}
 
 \begin{itemize}
+\item Removed references to \xmlel{vstd:StandardKeyEnumeration} which is now deprecated.
 \item Added en and pen to the list of document types.
 \item Adding regulations on record upload and key additions.
 \item Requiring new keys to be all-lowercase in order to simpify

--- a/StandardsRegExt.tex
+++ b/StandardsRegExt.tex
@@ -370,7 +370,7 @@ qualifier to a StandardsRegExt type name given as the value of an
 
 \subsection{Summary of Metadata Concepts}
 
-The StandardsRegExt extension defines three new types of resources.  Two
+The StandardsRegExt extension defines two new types of resources which
 are specifically for independently documented standards:
 
 \begin{description}
@@ -390,14 +390,7 @@ are specifically for independently documented standards:
        via its
        \xmlel{interface}
        element.
-\item[\xmlel{vstd:StandardKeyEnumeration}] This resource type allows for the description of a related set of \todo{Do we want to deprecate this?}
-       controlled names (referred to as \emph{keys}) and their
-       meanings.  While keys can be defined as part of a
-       \xmlel{vstd:Standard} or \xmlel{vstd:ServiceStandard}
-       resource, the \xmlel{vstd:StandardKeyEnumeration} allows
-       a set of key definitions to stand as a resource on its own,
-       regardless of whether it is part of a documented standard or
-       not.
+
 
 \end{description}
 

--- a/StandardsRegExt.tex
+++ b/StandardsRegExt.tex
@@ -1245,7 +1245,8 @@ as distributed by the Registry of Registries.
 \subsection{Changes since Rec-1.0}
 
 \begin{itemize}
-\item Removed references to \xmlel{vstd:StandardKeyEnumeration} which is now deprecated. 
+\item Removed references to \xmlel{vstd:StandardKeyEnumeration} (which is now deprecated)
+from this document and associated schema.
 Replaced computer language example by HiPS standard definition example.
 \item Added en and pen to the list of document types.
 \item Adding regulations on record upload and key additions.

--- a/StandardsRegExt.tex
+++ b/StandardsRegExt.tex
@@ -233,25 +233,26 @@ standard \citep{2018ivoa.spec.0723D} applies.
 
 \section{The StandardsRegExt Data Model}
 
-The StandardsRegExt extension in general enables the description of three
+The StandardsRegExt extension in general enables the description of two
 types of resources:
 
 \begin{itemize}
 \item  a generic standard (specified by an external document)
 \item  a standard specifically defining a service protocol
-\item  a set of related, standardized names called \emph{keys}.
 \end{itemize}
+
+Each type of resource can have a set of related, standardized names called \emph{keys}.
 
 Here's an example of defining the HiPS standard and its associated \emph{keys}.
 
 \begin{lstlisting}[language=xml]
-<ri:Resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<ri:Resource xsi:type="vstd:Standard"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:vstd="http://www.ivoa.net/xml/StandardsRegExt/v1.0"
 		xmlns:ri="http://www.ivoa.net/xml/RegistryInterface/v1.0"
 		created="2017-06-01T09:33:00Z"
 		updated="2017-06-01T09:33:00Z"
-		status="active"
-		xsi:type="vstd:Standard">
+		status="active">
   	<title>HiPS -- Hierarchical Progressive Survey</title>
   	<identifier>ivo://ivoa.net/std/hips</identifier>
   	<curation>
@@ -300,16 +301,6 @@ Here's an example of defining the HiPS standard and its associated \emph{keys}.
 </ri:Resource>
 \end{lstlisting}
 
-
-This description defines the meaning behind the following URI, namely
-the Python language,
-\nolinkurl{ivo://ivoa.net/std/application/languages#Python}.
-
-An application can thus refer to, for example, its support for the
-Python language via this URI.  Should other languages become
-prevalent, the resource description could be updated to add the new
-names, or a new resource description could be created (with a new IVOA
-identifier).
 
 
 
@@ -393,7 +384,7 @@ are specifically for independently documented standards:
 
 \begin{admonition}{Note}
        As mentioned above, this standard allows controlled names to be
-       defined either as part of a record of any of the above three
+       defined either as part of a record of any of the above two
        types.  When such names are being defined as part of an IVOA
        standard, it is recommended that the \xmlel{vstd:Standard} or
        \xmlel{vstd:ServiceStandard} record corresponding to the
@@ -425,7 +416,7 @@ that will likely change over time.
 
 The StandardsRegExt schema provides an alternative to XML Schema-based
 definitions of controlled names.  Instead, a controlled list of names,
-called \emph{standard keys}, can be defined as part of any of the three
+called \emph{standard keys}, can be defined as part of any of the two
 StandardsRegExt resource types.  Updating a resource description is much
 less disruptive than a Schema document, and as a resource is available
 via an IVOA-compliant registry, it is still possible for a
@@ -519,7 +510,7 @@ derived by extension from the \xmlel{vstd:StandardKey}.
 
 \subsection{Resource Type Extensions}
 
-This specification defined three new resource types.  As is spelled
+This specification defined two new resource types.  As is spelled
 out in the VOResource specification, a resource description indicates
 that it refers to one of these types of resources by setting the
 \xmlel{xsi:type} attribute to the namespace-qualified type name.
@@ -1255,7 +1246,8 @@ as distributed by the Registry of Registries.
 \subsection{Changes since Rec-1.0}
 
 \begin{itemize}
-\item Removed references to \xmlel{vstd:StandardKeyEnumeration} which is now deprecated.
+\item Removed references to \xmlel{vstd:StandardKeyEnumeration} which is now deprecated. 
+Replaced computer language example by HiPS standard definition example.
 \item Added en and pen to the list of document types.
 \item Adding regulations on record upload and key additions.
 \item Requiring new keys to be all-lowercase in order to simpify

--- a/StandardsRegExt.tex
+++ b/StandardsRegExt.tex
@@ -75,7 +75,7 @@ National Science Foundation's\footnote{\url{http://www.nsf.gov/}}
 Information Technology Research Program under Cooperative Agreement
 AST0122449 with The Johns Hopkins University, from the
 UK Particle Physics and Astronomy Research Council
-(PPARC)\footnote{\url{http://www.pparc.ac.uk/}\todo[inline]{BROKEN LINK}}, and from the
+(PPARC), and from the
 European Commission's Seventh Framework
 Program\footnote{\url{http://cordis.europa.eu/fp7/capacities/home_en.html}}.
 

--- a/StandardsRegExt.tex
+++ b/StandardsRegExt.tex
@@ -19,7 +19,6 @@
 \author[http://www.ivoa.net/twiki/bin/view/IVOA/DaveMorris]{Dave Morris}
 
 
-
 \editor[http://www.ivoa.net/twiki/bin/view/IVOA/RenaudSavalle]{Renaud Savalle}
 
 \previousversion[https://ivoa.net/documents/StandardsRegExt/20120508/]{REC-1.0}
@@ -76,7 +75,7 @@ National Science Foundation's\footnote{\url{http://www.nsf.gov/}}
 Information Technology Research Program under Cooperative Agreement
 AST0122449 with The Johns Hopkins University, from the
 UK Particle Physics and Astronomy Research Council
-(PPARC)\footnote{\url{http://www.pparc.ac.uk/}}, and from the
+(PPARC)\footnote{\url{http://www.pparc.ac.uk/}\todo[inline]{BROKEN LINK}}, and from the
 European Commission's Seventh Framework
 Program\footnote{\url{http://cordis.europa.eu/fp7/capacities/home_en.html}}.
 

--- a/StandardsRegExt.tex
+++ b/StandardsRegExt.tex
@@ -242,64 +242,61 @@ types of resources:
 \item  a set of related, standardized names called \emph{keys}.
 \end{itemize}
 
-
-Here's an example of defining a controlled list of computer languages
-that might be referred to in other descriptions of applications.
+Here's an example of defining the HiPS standard and its associated \emph{keys}.
 
 \begin{lstlisting}[language=xml]
-<ri:Resource xsi:type="vstd:StandardKeyEnumeration"
-  created="2001-12-31T12:00:00"
-  updated="2001-12-31T12:00:00" status="active">
-  <title>application languages</title>
-  <identifier>ivo://ivoa.net/std/application/languages</identifier>
-  <curation>
-     <publisher>IVOA</publisher>
-     <creator>
-        <name>IVOA</name>
-        <logo>http://www.ivoa.net/icons/ivoa_logo_small.jpg</logo>
-     </creator>
-     <date role="representative">2006-07-17</date>
-     <version>1.0</version>
-     <contact>
-        <name>IVOA Grid and Web Services WG</name>
-        <email>grid@ivoa.net</email>
-     </contact>
-  </curation>
-  <content>
-     <subject>IVOA Standard: registry</subject>
-     <description>
-        This resource defines keys for commonly used computer languages.
-     </description>
-     <referenceURL>http://www.ivoa.net/twiki/bin/view/IVOA/IvoaResReg</referenceURL>
-  </content>
-  <key>
-     <name>C</name>
-     <description>The C programming language</description>
-  </key>
-  <key>
-     <name>CPP</name>
-     <description>The C++ programming language</description>
-  </key>
-  <key>
-     <name>CSharp</name>
-     <description>The C# programming language</description>
-  </key>
-  <key>
-     <name>FORTRAN</name>
-     <description>The FORTRAN programming language</description>
-  </key>
-  <key>
-     <name>Java</name>
-     <description>The Java programming language</description>
-  </key>
-  <key>
-     <name>Perl</name>
-     <description>The Perl programming language</description>
-  </key>
-  <key>
-     <name>Python</name>
-     <description>The Python programming language</description>
-  </key>
+<ri:Resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns:vstd="http://www.ivoa.net/xml/StandardsRegExt/v1.0"
+		xmlns:ri="http://www.ivoa.net/xml/RegistryInterface/v1.0"
+		created="2017-06-01T09:33:00Z"
+		updated="2017-06-01T09:33:00Z"
+		status="active"
+		xsi:type="vstd:Standard">
+  	<title>HiPS -- Hierarchical Progressive Survey</title>
+  	<identifier>ivo://ivoa.net/std/hips</identifier>
+  	<curation>
+    	<publisher>IVOA Apps Working Group</publisher>
+    	<creator>
+      	<name>Fernique, P.</name>
+    	</creator>
+    	...
+    	<date role="created">2017-06-01T09:33:00</date>
+    	<contact>
+      		<name>IVOA Apps Working Group</name>
+      		<email>apps@ivoa.net</email>
+    	</contact>
+  	</curation>
+  	<content>
+    	<subject>Virtual observatory</subject>
+    	<subject>Standards</subject>
+    	<subject>HiPS</subject>
+		<description>
+			HiPS: a hierarchical scheme for the description, storage and access of 
+			sky survey data. The system is based on hierarchical tiling of sky regions 
+			at finer and finer spatial  resolution which facilitates a progressive 
+			view of a survey, and supports multi-resolution zooming and panning. 
+			HiPS uses the HEALPix tessellation of the sky as the basis for the scheme
+			and is implemented as a simple file structure with a direct indexing
+			scheme that leads to practical implementations.
+		</description>
+    	<referenceURL>http://ivoa.net/documents/HiPS</referenceURL>
+  	</content>
+  	<endorsedVersion status="rec" use="preferred">1.0</endorsedVersion>
+	<key>
+		<name>hipslist-1.0</name>
+		<description>
+			A service returning a list of HiPS identifiers
+			and metadata for HiPS.  This term is used to form a standardID,
+			for instance for use in vr:Capability.
+		</description>
+	</key>
+	<key>
+		<name>hips-1.0</name>
+		<description>
+			A single HiPS.  This term is used to form a standardID,
+			for instance for use in vr:Capability.
+		</description>
+	</key>
 </ri:Resource>
 \end{lstlisting}
 


### PR DESCRIPTION
- changes to deprecate the StandardKeyEnumeration resource type: removed from doc and schema
- replaced computer languages example which used StandardKeyEnumeration by a real life example: declaring the HiPS standard with keys.